### PR TITLE
Fix bug with parser

### DIFF
--- a/src/main/java/seedu/command/MistypedCommand.java
+++ b/src/main/java/seedu/command/MistypedCommand.java
@@ -1,0 +1,17 @@
+package seedu.command;
+
+import seedu.logic.MealManager;
+import seedu.ui.UserInterface;
+
+public class MistypedCommand extends Command {
+    private String actualCommand;
+
+    public MistypedCommand(String userInputText, String actualCommand) {
+        validUserInput = userInputText;
+        this.actualCommand = actualCommand;
+    }
+    @Override
+    public void execute(MealManager mealManager, UserInterface ui) {
+        ui.printMistypedCommand(validUserInput, actualCommand);
+    }
+}

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -10,6 +10,7 @@ import seedu.command.DeleteCommand;
 import seedu.command.FilterCommand;
 import seedu.command.HelpCommand;
 import seedu.command.InventoryCommand;
+import seedu.command.MistypedCommand;
 import seedu.command.RecipesCommand;
 import seedu.command.RecommendCommand;
 import seedu.command.RemoveCommand;
@@ -35,43 +36,63 @@ public class Parser {
     private static final String CONSUME = "consume";
     private static final String BUY = "buy";
     private static final String INVENTORY = "inventory";
+    private static final String[] allCommands = {BYE, CREATE, FILTER, SELECT, WISHLIST, RECIPES, CLEAR, HELP, REMOVE,
+        VIEW, DELETE, RECOMMEND, CONSUME, BUY, INVENTORY};
 
     public static Command parse(String userInput) throws EZMealPlanException {
-        String lowerCaseUserInput = userInput.toLowerCase().trim();
+        String firstWordLowerCase = getFirstWord(userInput).toLowerCase();
         userInput = userInput.trim();
-        if (lowerCaseUserInput.startsWith(BYE)) {
+        if (firstWordLowerCase.equals(BYE)) {
             return new ByeCommand();
-        } else if (lowerCaseUserInput.startsWith(CREATE)) {
+        } else if (firstWordLowerCase.equals(CREATE)) {
             return new CreateCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(FILTER)) {
+        } else if (firstWordLowerCase.equals(FILTER)) {
             return new FilterCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(SELECT)) {
+        } else if (firstWordLowerCase.equals(SELECT)) {
             return new SelectCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(RECIPES)) {
+        } else if (firstWordLowerCase.equals(RECIPES)) {
             return new RecipesCommand();
-        } else if (lowerCaseUserInput.startsWith(WISHLIST)) {
+        } else if (firstWordLowerCase.equals(WISHLIST)) {
             return new WishlistCommand();
-        } else if (lowerCaseUserInput.startsWith(CLEAR)) {
+        } else if (firstWordLowerCase.equals(CLEAR)) {
             return new ClearCommand();
-        } else if (lowerCaseUserInput.startsWith(HELP)) {
+        } else if (firstWordLowerCase.equals(HELP)) {
             return new HelpCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(REMOVE)) {
+        } else if (firstWordLowerCase.equals(REMOVE)) {
             return new RemoveCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(VIEW)) {
+        } else if (firstWordLowerCase.equals(VIEW)) {
             return new ViewCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(DELETE)) {
+        } else if (firstWordLowerCase.equals(DELETE)) {
             return new DeleteCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(RECOMMEND)) {
+        } else if (firstWordLowerCase.equals(RECOMMEND)) {
             return new RecommendCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(CONSUME)) {
+        } else if (firstWordLowerCase.equals(CONSUME)) {
             return new ConsumeCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(BUY)) {
+        } else if (firstWordLowerCase.equals(BUY)) {
             return new BuyCommand(userInput);
-        } else if (lowerCaseUserInput.startsWith(INVENTORY)) {
+        } else if (firstWordLowerCase.equals(INVENTORY)) {
             return new InventoryCommand();
         } else {
-            return new UnknownCommand(userInput);
+            return parseUnknownInput(firstWordLowerCase);
         }
+    }
+
+    private static String getFirstWord(String userInput) {
+        int firstSpaceIndex = userInput.indexOf(' ');
+        if (firstSpaceIndex == -1) {
+            //userInput does not contain a space
+            return userInput;
+        }
+        return userInput.substring(0, firstSpaceIndex);
+    }
+
+    private static Command parseUnknownInput(String firstWordLowerCase) {
+        for (String commandString : allCommands) {
+            if (firstWordLowerCase.startsWith(commandString)) {
+                return new MistypedCommand(firstWordLowerCase, commandString);
+            }
+        }
+        return new UnknownCommand(firstWordLowerCase);
     }
 }
 

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -42,39 +42,24 @@ public class Parser {
     public static Command parse(String userInput) throws EZMealPlanException {
         String firstWordLowerCase = getFirstWord(userInput).toLowerCase();
         userInput = userInput.trim();
-        if (firstWordLowerCase.equals(BYE)) {
-            return new ByeCommand();
-        } else if (firstWordLowerCase.equals(CREATE)) {
-            return new CreateCommand(userInput);
-        } else if (firstWordLowerCase.equals(FILTER)) {
-            return new FilterCommand(userInput);
-        } else if (firstWordLowerCase.equals(SELECT)) {
-            return new SelectCommand(userInput);
-        } else if (firstWordLowerCase.equals(RECIPES)) {
-            return new RecipesCommand();
-        } else if (firstWordLowerCase.equals(WISHLIST)) {
-            return new WishlistCommand();
-        } else if (firstWordLowerCase.equals(CLEAR)) {
-            return new ClearCommand();
-        } else if (firstWordLowerCase.equals(HELP)) {
-            return new HelpCommand(userInput);
-        } else if (firstWordLowerCase.equals(REMOVE)) {
-            return new RemoveCommand(userInput);
-        } else if (firstWordLowerCase.equals(VIEW)) {
-            return new ViewCommand(userInput);
-        } else if (firstWordLowerCase.equals(DELETE)) {
-            return new DeleteCommand(userInput);
-        } else if (firstWordLowerCase.equals(RECOMMEND)) {
-            return new RecommendCommand(userInput);
-        } else if (firstWordLowerCase.equals(CONSUME)) {
-            return new ConsumeCommand(userInput);
-        } else if (firstWordLowerCase.equals(BUY)) {
-            return new BuyCommand(userInput);
-        } else if (firstWordLowerCase.equals(INVENTORY)) {
-            return new InventoryCommand();
-        } else {
-            return parseUnknownInput(firstWordLowerCase);
-        }
+        return switch (firstWordLowerCase) {
+        case BYE -> new ByeCommand();
+        case CREATE -> new CreateCommand(userInput);
+        case FILTER -> new FilterCommand(userInput);
+        case SELECT -> new SelectCommand(userInput);
+        case RECIPES -> new RecipesCommand();
+        case WISHLIST -> new WishlistCommand();
+        case CLEAR -> new ClearCommand();
+        case HELP -> new HelpCommand(userInput);
+        case REMOVE -> new RemoveCommand(userInput);
+        case VIEW -> new ViewCommand(userInput);
+        case DELETE -> new DeleteCommand(userInput);
+        case RECOMMEND -> new RecommendCommand(userInput);
+        case CONSUME -> new ConsumeCommand(userInput);
+        case BUY -> new BuyCommand(userInput);
+        case INVENTORY -> new InventoryCommand();
+        default -> parseUnknownInput(firstWordLowerCase);
+        };
     }
 
     private static String getFirstWord(String userInput) {
@@ -87,9 +72,9 @@ public class Parser {
     }
 
     private static Command parseUnknownInput(String firstWordLowerCase) {
-        for (String commandString : allCommandStrings) {
-            if (firstWordLowerCase.startsWith(commandString)) {
-                return new MistypedCommand(firstWordLowerCase, commandString);
+        for (String actualCommandString : allCommandStrings) {
+            if (firstWordLowerCase.startsWith(actualCommandString)) {
+                return new MistypedCommand(firstWordLowerCase, actualCommandString);
             }
         }
         return new UnknownCommand(firstWordLowerCase);

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -36,8 +36,8 @@ public class Parser {
     private static final String CONSUME = "consume";
     private static final String BUY = "buy";
     private static final String INVENTORY = "inventory";
-    private static final String[] allCommands = {BYE, CREATE, FILTER, SELECT, WISHLIST, RECIPES, CLEAR, HELP, REMOVE,
-        VIEW, DELETE, RECOMMEND, CONSUME, BUY, INVENTORY};
+    private static final String[] allCommandStrings = {BYE, CREATE, FILTER, SELECT, WISHLIST, RECIPES, CLEAR, HELP,
+        REMOVE, VIEW, DELETE, RECOMMEND, CONSUME, BUY, INVENTORY};
 
     public static Command parse(String userInput) throws EZMealPlanException {
         String firstWordLowerCase = getFirstWord(userInput).toLowerCase();
@@ -87,7 +87,7 @@ public class Parser {
     }
 
     private static Command parseUnknownInput(String firstWordLowerCase) {
-        for (String commandString : allCommands) {
+        for (String commandString : allCommandStrings) {
             if (firstWordLowerCase.startsWith(commandString)) {
                 return new MistypedCommand(firstWordLowerCase, commandString);
             }

--- a/src/main/java/seedu/ui/UserInterface.java
+++ b/src/main/java/seedu/ui/UserInterface.java
@@ -42,6 +42,11 @@ public class UserInterface {
         System.out.println("me no understand what you talking.");
     }
 
+    public void printMistypedCommand(String userInput, String actualCommand) {
+        System.out.println("Invalid command: " + userInput);
+        System.out.println("Did you mean: " + actualCommand + "?");
+    }
+
     public void printErrorMessage(Exception exception) {
         System.out.println(exception.getMessage());
     }

--- a/src/test/java/seedu/parser/ParserTest.java
+++ b/src/test/java/seedu/parser/ParserTest.java
@@ -5,12 +5,45 @@ import seedu.command.MistypedCommand;
 import seedu.command.UnknownCommand;
 import seedu.exceptions.EZMealPlanException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.io.IOException;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class ParserTest {
+    private static final Logger logger = Logger.getLogger(Parser.class.getName());
+
+    public ParserTest() {
+        String fileName = "ParserTest.log";
+        setupLogger(fileName);
+    }
+
+    private static void setupLogger(String fileName) {
+        LogManager.getLogManager().reset();
+        logger.setLevel(Level.ALL);
+        ConsoleHandler consoleHandler = new ConsoleHandler();
+        consoleHandler.setLevel(Level.INFO);
+        logger.addHandler(consoleHandler);
+        createLogFile(fileName);
+    }
+
+    private static void createLogFile(String fileName) {
+        try {
+            FileHandler fileHandler = new FileHandler(fileName, true);
+            fileHandler.setLevel(Level.FINE);
+            logger.addHandler(fileHandler);
+        } catch (IOException ioException) {
+            logger.log(Level.SEVERE, "File logger is not working.", ioException);
+        }
+    }
 
     @Test
     public void parse_mistypedInput_returnsMistypedCommand() throws EZMealPlanException {
+        logger.fine("Running parse_mistypedInput_returnsMistypedCommand()");
         String testInput1 = "wishlists";
         String testInput2 = "filter/ing ingredient";
         String testInput3 = "delete1";
@@ -23,10 +56,12 @@ class ParserTest {
         assertInstanceOf(MistypedCommand.class, Parser.parse(testInput4));
         assertInstanceOf(MistypedCommand.class, Parser.parse(testInput5));
         assertInstanceOf(MistypedCommand.class, Parser.parse(testInput6));
+        logger.info("Correct command object instantiated");
     }
 
     @Test
     public void parse_unknownInput_returnsUnknownCommand() throws EZMealPlanException {
+        logger.fine("Running parse_unknownInput_returnsUnknownCommand()");
         String testInput1 = "wish list";
         String testInput2 = "reccomend /ing 1";
         String testInput3 = "by e";
@@ -35,5 +70,6 @@ class ParserTest {
         assertInstanceOf(UnknownCommand.class, Parser.parse(testInput2));
         assertInstanceOf(UnknownCommand.class, Parser.parse(testInput3));
         assertInstanceOf(UnknownCommand.class, Parser.parse(testInput4));
+        logger.info("Correct command object instantiated");
     }
 }

--- a/src/test/java/seedu/parser/ParserTest.java
+++ b/src/test/java/seedu/parser/ParserTest.java
@@ -1,0 +1,39 @@
+package seedu.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.command.MistypedCommand;
+import seedu.command.UnknownCommand;
+import seedu.exceptions.EZMealPlanException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParserTest {
+
+    @Test
+    public void parse_mistypedInput_returnsMistypedCommand() throws EZMealPlanException {
+        String testInput1 = "wishlists";
+        String testInput2 = "filter/ing ingredient";
+        String testInput3 = "delete1";
+        String testInput4 = "remove1 1";
+        String testInput5 = "viewwishlist";
+        String testInput6 = "helpselect";
+        assertInstanceOf(MistypedCommand.class, Parser.parse(testInput1));
+        assertInstanceOf(MistypedCommand.class, Parser.parse(testInput2));
+        assertInstanceOf(MistypedCommand.class, Parser.parse(testInput3));
+        assertInstanceOf(MistypedCommand.class, Parser.parse(testInput4));
+        assertInstanceOf(MistypedCommand.class, Parser.parse(testInput5));
+        assertInstanceOf(MistypedCommand.class, Parser.parse(testInput6));
+    }
+
+    @Test
+    public void parse_unknownInput_returnsUnknownCommand() throws EZMealPlanException {
+        String testInput1 = "wish list";
+        String testInput2 = "reccomend /ing 1";
+        String testInput3 = "by e";
+        String testInput4 = "creat egg /ing raw egg (1)";
+        assertInstanceOf(UnknownCommand.class, Parser.parse(testInput1));
+        assertInstanceOf(UnknownCommand.class, Parser.parse(testInput2));
+        assertInstanceOf(UnknownCommand.class, Parser.parse(testInput3));
+        assertInstanceOf(UnknownCommand.class, Parser.parse(testInput4));
+    }
+}


### PR DESCRIPTION
Fix a bug where trailing letters after a registered command (e.g. `wishlistt`) and commands without a space between the command and parameters gets accepted, due to the use of `startsWith` in `Parser.java`. 

Add new `MistypedCommand` class to deal with such problems.

Add JUnit tests for `Parser.java`, testing for unknown and mistyped commands.

Closes #125 and other duplicates.