### PR TITLE
Improve Test Coverage

### DIFF
--- a/src/main/java/seedu/exceptions/EZMealPlanException.java
+++ b/src/main/java/seedu/exceptions/EZMealPlanException.java
@@ -1,6 +1,8 @@
 package seedu.exceptions;
 
 public class EZMealPlanException extends Exception {
+    public EZMealPlanException() {}
+
     @Override
     public String getMessage() {
         return super.getMessage();

--- a/src/main/java/seedu/exceptions/InvalidViewIndexException.java
+++ b/src/main/java/seedu/exceptions/InvalidViewIndexException.java
@@ -1,6 +1,7 @@
 package seedu.exceptions;
 
 public class InvalidViewIndexException extends EZMealPlanException {
+    public InvalidViewIndexException() {}
 
     @Override
     public String getMessage() {

--- a/src/main/java/seedu/exceptions/InvalidViewKeywordException.java
+++ b/src/main/java/seedu/exceptions/InvalidViewKeywordException.java
@@ -1,6 +1,8 @@
 package seedu.exceptions;
 
 public class InvalidViewKeywordException extends EZMealPlanException {
+    public InvalidViewKeywordException() {}
+
     @Override
     public String getMessage() {
         return "Only 1 of the keywords '/r' (recipes list) or '/w' (wishlist) is allowed" +

--- a/src/main/java/seedu/food/Ingredient.java
+++ b/src/main/java/seedu/food/Ingredient.java
@@ -39,6 +39,16 @@ public class Ingredient extends Product {
         }
     }
 
+    public boolean nameEquals(Object otherIngredient) {
+        if (otherIngredient instanceof Ingredient) {
+            String otherName = ((Ingredient) otherIngredient).getName();
+            String thisName = this.getName();
+            return thisName.equalsIgnoreCase(otherName);
+        } else {
+            return false;
+        }
+    }
+
     private double checkValidIngPrice(String ingredientPrice) throws IngredientPriceFormatException {
         checkTwoDecimalPlace(ingredientPrice);
         try {

--- a/src/main/java/seedu/food/Inventory.java
+++ b/src/main/java/seedu/food/Inventory.java
@@ -112,7 +112,7 @@ public class Inventory {
             outputString.append(ingredient);
             outputString.append(": ");
             outputString.append(ingredients.get(ingredient));
-            outputString.append("\n");
+            outputString.append(System.lineSeparator());
         }
         return outputString.toString();
     }

--- a/src/main/java/seedu/food/Meal.java
+++ b/src/main/java/seedu/food/Meal.java
@@ -54,7 +54,7 @@ public class Meal extends Product {
 
     private void checkDuplicateIngredients(Ingredient newIngredient) throws DuplicateIngredientException {
         for (Ingredient ingredient : ingredientList) {
-            if (newIngredient.equals(ingredient)) {
+            if (newIngredient.nameEquals(ingredient)) {
                 String ingredientName = newIngredient.getName();
                 String message = "Triggers DuplicateIngredientException()!";
                 logger.warning(message);

--- a/src/main/java/seedu/meallist/MealList.java
+++ b/src/main/java/seedu/meallist/MealList.java
@@ -2,6 +2,7 @@ package seedu.meallist;
 
 import seedu.exceptions.DuplicateMealException;
 import seedu.exceptions.EZMealPlanException;
+import seedu.exceptions.EmptyListException;
 import seedu.exceptions.MealNotFoundException;
 import seedu.exceptions.RemoveIndexOutOfRangeException;
 import seedu.food.Meal;
@@ -44,6 +45,9 @@ public abstract class MealList {
      * Removes the meal at a specified index and returns it.
      */
     public Meal removeMeal(int index) throws EZMealPlanException {
+        if (mealList.isEmpty()) {
+            throw new EmptyListException(mealListName);
+        }
         try {
             return mealList.remove(index);
         } catch (IndexOutOfBoundsException indexOutOfBoundsException) {

--- a/src/test/java/seedu/checkers/ViewCheckerTest.java
+++ b/src/test/java/seedu/checkers/ViewCheckerTest.java
@@ -1,7 +1,5 @@
 package seedu.checkers;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.io.IOException;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
@@ -15,7 +13,10 @@ import org.junit.jupiter.api.Test;
 import seedu.exceptions.EZMealPlanException;
 import seedu.exceptions.InvalidKeywordIndexException;
 import seedu.exceptions.MissingMealIndexException;
-import seedu.exceptions.InvalidViewIndexException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ViewCheckerTest {
 
@@ -59,7 +60,12 @@ public class ViewCheckerTest {
     public void viewChecker_keywordBeforeView_throwsInvalidKeywordIndexException() {
         logger.fine("Running viewChecker_keywordBeforeView_throwsInvalidKeywordIndexException()");
         ViewChecker checker = new ViewChecker("/r view 1", "/r");
-        assertThrows(InvalidKeywordIndexException.class, checker::check);
+        try {
+            checker.check();
+        } catch (EZMealPlanException ezMealPlanException) {
+            String expectedMessage = "'/r' must be present after the 'view' keyword in the 'view' command.\n";
+            assertEquals(expectedMessage, ezMealPlanException.getMessage());
+        }
         logger.info("viewChecker_keywordBeforeView_throwsInvalidKeywordIndexException passed");
     }
 
@@ -75,7 +81,13 @@ public class ViewCheckerTest {
     public void viewChecker_nonIntegerIndex_throwsInvalidViewIndexException() {
         logger.fine("Running viewChecker_nonIntegerIndex_throwsInvalidViewIndexException()");
         ViewChecker checker = new ViewChecker("view /r abc", "/r");
-        assertThrows(InvalidViewIndexException.class, checker::check);
+        try {
+            checker.check();
+            fail();
+        } catch (EZMealPlanException ezMealPlanException) {
+            String expectedMessage = "The meal list index in the 'view' command must be parsable into an integer.\n";
+            assertEquals(expectedMessage, ezMealPlanException.getMessage());
+        }
         logger.info("viewChecker_nonIntegerIndex_throwsInvalidViewIndexException passed");
     }
 

--- a/src/test/java/seedu/command/BuyCommandTest.java
+++ b/src/test/java/seedu/command/BuyCommandTest.java
@@ -24,6 +24,8 @@ class BuyCommandTest {
     private static final Logger logger = Logger.getLogger(BuyCommandTest.class.getName());
     private final UserInterface ui = new UserInterface();
 
+    private final String ls = System.lineSeparator();
+
     public BuyCommandTest() {
         String fileName = "BuyCommandTest.log";
         setupLogger(fileName);
@@ -57,10 +59,7 @@ class BuyCommandTest {
         command.execute(mealManager, ui);
 
         Inventory inventory = mealManager.getInventory();
-        String expectedOutput = """
-                    1. Apple ($1.00): 1
-                    2. Banana ($3.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 1" + ls + "    2. Banana ($3.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredients added");
     }
@@ -74,10 +73,7 @@ class BuyCommandTest {
         command.execute(mealManager, ui);
 
         Inventory inventory = mealManager.getInventory();
-        String expectedOutput = """
-                    1. Apple ($1.00): 2
-                    2. Banana ($3.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 2" + ls + "    2. Banana ($3.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredients added");
     }
@@ -91,11 +87,8 @@ class BuyCommandTest {
         command.execute(mealManager, ui);
 
         Inventory inventory = mealManager.getInventory();
-        String expectedOutput = """
-                    1. Apple ($1.00): 1
-                    2. Apple ($2.00): 1
-                    3. Banana ($3.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 1" + ls + "    2. Apple ($2.00): 1" + ls +
+                "    3. Banana ($3.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredients added");
     }

--- a/src/test/java/seedu/command/ConsumeCommandTest.java
+++ b/src/test/java/seedu/command/ConsumeCommandTest.java
@@ -27,8 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConsumeCommandTest {
     private static final Logger logger = Logger.getLogger(ConsumeCommandTest.class.getName());
+    private final UserInterface ui = new UserInterface();
+    private final String ls = System.lineSeparator();
 
-    UserInterface ui = new UserInterface();
     private final Ingredient ingredient1;
     private final Ingredient ingredient2;
     private final Ingredient ingredient3;
@@ -75,10 +76,7 @@ class ConsumeCommandTest {
         Command command = new ConsumeCommand(userInput);
         command.execute(mealManager, ui);
 
-        String expectedOutput = """
-                    1. Banana ($3.00): 1
-                    2. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Banana ($3.00): 1" + ls + "    2. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredient consumed");
     }
@@ -110,16 +108,13 @@ class ConsumeCommandTest {
         Command command = new ConsumeCommand(userInput);
         command.execute(mealManager, ui);
 
-        String expectedOutput = """
-                    1. Banana ($3.00): 1
-                    2. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Banana ($3.00): 1" + ls + "    2. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredient consumed");
     }
 
     @Test
-    public void testExecute_ingredientNotFoundWithPriceInput_exceptionThrown() throws EZMealPlanException {
+    public void testExecute_ingredientNotFoundWithPriceInput_exceptionThrown() {
         logger.fine("Running testExecute_ingredientNotFoundWithPriceInput_exceptionThrown()");
         MealManager mealManager = new MealManager();
         Inventory inventory = mealManager.getInventory();
@@ -145,9 +140,7 @@ class ConsumeCommandTest {
         Command command = new ConsumeCommand(userInput);
         command.execute(mealManager, ui);
 
-        String expectedOutput = """
-                    1. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredients consumed");
     }
@@ -166,11 +159,8 @@ class ConsumeCommandTest {
         Command command = new ConsumeCommand(userInput);
         command.execute(mealManager, ui);
 
-        String expectedOutput = """
-                    1. Apple ($1.00): 2
-                    2. Banana ($3.00): 1
-                    3. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 2" + ls + "    2. Banana ($3.00): 1" + ls +
+                "    3. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredient consumed");
     }
@@ -189,11 +179,8 @@ class ConsumeCommandTest {
         Command command1 = new ConsumeCommand(userInput1);
         command1.execute(mealManager, ui);
 
-        String expectedOutput = """
-                    1. Apple ($1.00): 2
-                    2. Apple ($2.00): 1
-                    3. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 2" + ls + "    2. Apple ($2.00): 1" + ls +
+                "    3. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredient consumed");
 
@@ -218,12 +205,8 @@ class ConsumeCommandTest {
         Command command = new ConsumeCommand(userInput);
         command.execute(mealManager, ui);
 
-        String expectedOutput = """
-                    1. Apple ($1.00): 1
-                    2. Apple ($2.00): 1
-                    3. Banana ($3.00): 1
-                    4. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 1" + ls + "    2. Apple ($2.00): 1" + ls +
+                "    3. Banana ($3.00): 1" + ls + "    4. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredient consumed");
     }
@@ -267,11 +250,8 @@ class ConsumeCommandTest {
         Command command = new ConsumeCommand(userInput);
         command.execute(mealManager, ui);
 
-        String expectedOutput = """
-                    1. Apple ($1.00): 1
-                    2. Banana ($3.00): 1
-                    3. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 1" + ls + "    2. Banana ($3.00): 1" + ls +
+                "    3. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
         logger.info("Correct ingredient consumed");
     }

--- a/src/test/java/seedu/command/CreateCommandTest.java
+++ b/src/test/java/seedu/command/CreateCommandTest.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class CreateCommandTest {
@@ -203,6 +204,7 @@ public class CreateCommandTest {
         logger.fine(fineMsg);
         try {
             command.execute(mealManager, ui);
+            fail();
         } catch (EZMealPlanException ezMealPlanException) {
             String chickenBreast = "chicken breast";
             assertEquals(new DuplicateIngredientException(chickenBreast, chickenBreast).getMessage()

--- a/src/test/java/seedu/command/InventoryCommandTest.java
+++ b/src/test/java/seedu/command/InventoryCommandTest.java
@@ -25,6 +25,7 @@ class InventoryCommandTest {
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;
     private final UserInterface ui = new UserInterface();
+    private final String ls = System.lineSeparator();
 
     public InventoryCommandTest() {
         String fileName = "InventoryCommandTest.log";
@@ -76,13 +77,9 @@ class InventoryCommandTest {
         Command command = new InventoryCommand();
         command.execute(mealManager, ui);
 
-        String expectedString = """
-                Here are the ingredients that you own:\r
-                    1. Apple ($1.00): 2
-                    2. Apple ($2.00): 1
-                    3. Banana ($3.00): 1
-                """;
-        assertEquals(expectedString, outContent.toString());
+        String expectedString = "Here are the ingredients that you own:" + ls + "    1. Apple ($1.00): 2" + ls +
+                "    2. Apple ($2.00): 1" + ls + "    3. Banana ($3.00): 1" + ls;
+        assertEquals(expectedString.trim(), outContent.toString().trim());
         logger.info("Correct inventory printed");
     }
 

--- a/src/test/java/seedu/command/ViewCommandTest.java
+++ b/src/test/java/seedu/command/ViewCommandTest.java
@@ -115,6 +115,30 @@ public class ViewCommandTest {
     }
 
     @Test
+    public void testExecute_wrongKeyword_exceptionThrown() throws EZMealPlanException {
+        logger.fine("Running testExecute_wrongKeyword_exceptionThrown()");
+        MealManager mealManager = new MealManager();
+        Meal meal = new Meal("Wishlist Meal 1");
+        Ingredient firstIngredient = new Ingredient("tofu", "1.20");
+        Ingredient secondIngredient = new Ingredient("noodles", "1.80");
+        meal.addIngredient(firstIngredient);
+        meal.addIngredient(secondIngredient);
+
+        mealManager.getWishList().getList().add(meal);
+
+        TestUserInterface testUI = new TestUserInterface();
+        ViewCommand command = new ViewCommand("view /u 1");
+        try {
+            command.execute(mealManager, testUI);
+        } catch (EZMealPlanException ezMealPlanException) {
+            String expectedMessage = "Only 1 of the keywords '/r' (recipes list) or '/w' (wishlist) is allowed" +
+                    " and must be present in the 'view' command.\n";
+            assertEquals(expectedMessage, ezMealPlanException.getMessage());
+        }
+        logger.info("testExecute_wrongKeyword_exceptionThrown passed");
+    }
+
+    @Test
     public void testExecute_viewRecipesMeal_emptyList(){
         logger.fine("Running testExecute_viewRecipesMeal_emptyList()");
         MealManager mealManager = new MealManager();
@@ -150,8 +174,14 @@ public class ViewCommandTest {
         TestUserInterface testUI = new TestUserInterface();
         ViewCommand command = new ViewCommand("view /r 2");
 
+        try {
+            command.execute(mealManager, testUI);
+        } catch (EZMealPlanException ezMealPlanException) {
+            String expectedMessage = "The index provided for the recipes list (2) is out of range.\n" +
+                    "It must be between 1 and 1.\n";
+            assertEquals(expectedMessage, ezMealPlanException.getMessage());
+        }
         assertThrows(ViewIndexOutOfRangeException.class, () -> command.execute(mealManager,testUI));
-
         logger.info("testExecute_viewRecipesMeal_outOfRange passed");
     }
 

--- a/src/test/java/seedu/food/InventoryTest.java
+++ b/src/test/java/seedu/food/InventoryTest.java
@@ -1,13 +1,13 @@
 package seedu.food;
 
+import org.junit.jupiter.api.Test;
+import seedu.exceptions.EZMealPlanException;
 import seedu.exceptions.IngredientPriceFormatException;
 import seedu.exceptions.InvalidPriceException;
 import seedu.exceptions.InventoryIngredientNotFound;
 import seedu.exceptions.InventoryMultipleIngredientsException;
 
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class InventoryTest {
@@ -16,6 +16,8 @@ class InventoryTest {
     private final Ingredient ingredient3;
     private final Ingredient ingredient4;
     private final Ingredient ingredient5;
+
+    private final String ls = System.lineSeparator();
 
     public InventoryTest() throws InvalidPriceException, IngredientPriceFormatException {
         ingredient1 = new Ingredient("Apple", "1.00");
@@ -31,11 +33,8 @@ class InventoryTest {
         inventory.addIngredient(ingredient1);
         inventory.addIngredient(ingredient3);
         inventory.addIngredient(ingredient4);
-        String expectedOutput = """
-                    1. Apple ($1.00): 1
-                    2. Banana ($3.00): 1
-                    3. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 1" + ls + "    2. Banana ($3.00): 1" + ls +
+                "    3. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
     }
 
@@ -46,11 +45,8 @@ class InventoryTest {
         inventory.addIngredient(ingredient5);
         inventory.addIngredient(ingredient3);
         inventory.addIngredient(ingredient4);
-        String expectedOutput = """
-                    1. Apple ($1.00): 2
-                    2. Banana ($3.00): 1
-                    3. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 2" + ls + "    2. Banana ($3.00): 1" + ls +
+                "    3. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
     }
 
@@ -61,12 +57,8 @@ class InventoryTest {
         inventory.addIngredient(ingredient2);
         inventory.addIngredient(ingredient3);
         inventory.addIngredient(ingredient4);
-        String expectedOutput = """
-                    1. Apple ($1.00): 1
-                    2. Apple ($2.00): 1
-                    3. Banana ($3.00): 1
-                    4. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 1" + ls + "    2. Apple ($2.00): 1" + ls +
+                "    3. Banana ($3.00): 1" + ls + "    4. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
     }
 
@@ -78,10 +70,7 @@ class InventoryTest {
         inventory.addIngredient(ingredient3);
         inventory.addIngredient(ingredient4);
         inventory.removeIngredient("Apple");
-        String expectedOutput = """
-                    1. Banana ($3.00): 1
-                    2. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Banana ($3.00): 1" + ls + "    2. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
     }
 
@@ -94,11 +83,8 @@ class InventoryTest {
         inventory.addIngredient(ingredient3);
         inventory.addIngredient(ingredient4);
         inventory.removeIngredient("Apple");
-        String expectedOutput = """
-                    1. Apple ($1.00): 1
-                    2. Banana ($3.00): 1
-                    3. Chocolate ($4.00): 1
-                """;
+        String expectedOutput = "    1. Apple ($1.00): 1" + ls + "    2. Banana ($3.00): 1" + ls +
+                "    3. Chocolate ($4.00): 1" + ls;
         assertEquals(expectedOutput, inventory.toString());
     }
 
@@ -109,8 +95,14 @@ class InventoryTest {
         inventory.addIngredient(ingredient2);
         inventory.addIngredient(ingredient3);
         inventory.addIngredient(ingredient4);
-        assertThrows(InventoryMultipleIngredientsException.class,
-                () -> inventory.removeIngredient("Apple"));
+        try {
+            inventory.removeIngredient("Apple");
+            fail();
+        } catch (EZMealPlanException ezMealPlanException) {
+            String expectedMessage = "There are multiple ingredients with the same name present in the Inventory: \n" +
+                    "Apple ($1.00)\n" + "Apple ($2.00)\n" + "Please refine your arguments.";
+            assertEquals(expectedMessage, ezMealPlanException.getMessage());
+        }
     }
 
     @Test
@@ -122,8 +114,8 @@ class InventoryTest {
         try {
             inventory.removeIngredient("Chocolate");
             fail();
-        } catch (InventoryIngredientNotFound exception) {
-            assertEquals("Chocolate not found in Inventory", exception.getMessage());
+        } catch (EZMealPlanException ezMealPlanException) {
+            assertEquals("Chocolate not found in Inventory", ezMealPlanException.getMessage());
         }
     }
 }

--- a/src/test/java/seedu/meallist/MealListTest.java
+++ b/src/test/java/seedu/meallist/MealListTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.exceptions.DuplicateMealException;
 import seedu.exceptions.EZMealPlanException;
-import seedu.exceptions.MealNotFoundException;
 import seedu.exceptions.RemoveIndexOutOfRangeException;
 import seedu.food.Ingredient;
 import seedu.food.Meal;
@@ -20,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class MealListTest {
     private static final Logger logger = Logger.getLogger(MealListTest.class.getName());
@@ -100,7 +100,25 @@ class MealListTest {
         recipesList.addMeal(meal2);
         recipesList.addMeal(meal3);
         assertThrows(RemoveIndexOutOfRangeException.class, () -> recipesList.removeMeal(-1));
-        assertThrows(RemoveIndexOutOfRangeException.class, () -> recipesList.removeMeal(3));
+        try {
+            recipesList.removeMeal(3);
+        } catch (EZMealPlanException ezMealPlanException) {
+            String expectedMessage = "The index provided (4) is out of range. It must be between 1 and 3.\n";
+            assertEquals(expectedMessage, ezMealPlanException.getMessage());
+        }
+        logger.info("Correct Exception is thrown");
+    }
+
+    @Test
+    void removeMeal_emptyMealList_exceptionThrown() throws EZMealPlanException {
+        logger.fine("Running removeMeal_emptyMealList_exceptionThrown()");
+        MealList wishList = new WishList();
+        try {
+            wishList.removeMeal(1);
+        } catch (EZMealPlanException ezMealPlanException) {
+            String expectedMessage = "The wishlist is empty.\n";
+            assertEquals(expectedMessage, ezMealPlanException.getMessage());
+        }
         logger.info("Correct Exception is thrown");
     }
 
@@ -123,7 +141,13 @@ class MealListTest {
         MealList recipesList = new RecipesList();
         recipesList.addMeal(meal1);
         recipesList.addMeal(meal2);
-        assertThrows(MealNotFoundException.class, () -> recipesList.getIndex(meal3));
+        try {
+            recipesList.getIndex(meal3);
+            fail();
+        } catch (EZMealPlanException ezMealPlanException) {
+            String expectedMessage = "The meal provided (" + meal3 + ") cannot be found in the list.\n";
+            assertEquals(expectedMessage, ezMealPlanException.getMessage());
+        }
         logger.info("Correct Exception is thrown");
     }
 


### PR DESCRIPTION
Improve test coverage to 99% by testing for Exception messages.

Use `lineSeparator` to improve inter-operability between different OSes (there seems to be inconsistncies for `\n` or \r\n`)